### PR TITLE
[FIX] fix path typo in spmup_comp_dist2surf

### DIFF
--- a/utilities/spmup_comp_dist2surf.m
+++ b/utilities/spmup_comp_dist2surf.m
@@ -50,7 +50,7 @@ if isempty(surface_file)
         davg = 50; % we give it a default value if anything fails
     else
         spm_surf(files, 2);
-        surface_file = spm_select('FPList', spath, '.*\.surf\.gii$');
+        surface_file = spm_select('FPList', path, '.*\.surf\.gii$');
     end    
 end
 


### PR DESCRIPTION
one of my test relying on this started failing after I finally updated to the latest version

seems to have been changed there

https://github.com/CPernet/spmup/commit/b2c22993d8fab83bd0b0e66b4cbac9b9b475c079 