### PR TITLE
update identification of motion_file

### DIFF
--- a/QA/spmup_realign_qa.m
+++ b/QA/spmup_realign_qa.m
@@ -141,42 +141,18 @@ findex              = 1; % index for the new_files variables
 [filepath,filename] = fileparts(V(1).fname);
 motion_file         = dir(fullfile(filepath,'rp*.txt'));
 
-% get name parts for filename
-fparts = strsplit(filename, '_');
-fstruct = struct();
-for i = 1:numel(fparts)
-    kvparts = strsplit(fparts{i}, '-');
-    if numel(kvparts) < 2
-        continue
-    end
-    fstruct.(kvparts{1}) = kvparts{2};
-end
+% filename task
+fparts      = strsplit(filename, '_');
+fidx        = find(~cellfun(@isempty, regexp(fparts, '^(task)', 'once'), 'UniformOutput', true));
 
 % identify motion file that matches filename
 match = false;
 counter = 1;
 while ~match
     mparts = strsplit(motion_file(counter).name, '_');
-    mstruct = struct();
-    for i = 1:numel(mparts)
-        kvparts = strsplit(mparts{i}, '-');
-        if numel(kvparts) < 2
-            continue
-        end
-        mstruct.(kvparts{1}) = kvparts{2};
-    end
-    % update motion_file if all rp*txt file fields match respective fields
-    % for filename
-    mfields = fields(mstruct);
-    mfieldmatches = zeros(1,numel(mfields));
-    for i = 1:numel(mfields)
-        if ismember(mfields{i}, fields(fstruct))
-            if strcmpi(mstruct.(mfields{i}), fstruct.(mfields{i}))
-                mfieldmatches(1,i) = 1;
-            end
-        end
-    end
-    if all(mfieldmatches)
+    midx   = find(~cellfun(@isempty, regexp(mparts, '^(task)', 'once'), 'UniformOutput', true));
+    
+    if strcmp(fparts{fidx}, mparts{midx})
         match = true;
         motion_file = fullfile(filepath, motion_file(counter).name);
     else
@@ -197,6 +173,7 @@ if strcmpi(MotionParameters,'on')
 else
     FD = [];
 end
+
 %% look at globals
 
 if strcmpi(Globals,'on')   

--- a/QA/spmup_realign_qa.m
+++ b/QA/spmup_realign_qa.m
@@ -167,7 +167,16 @@ while ~match
     end
     % update motion_file if all rp*txt file fields match respective fields
     % for filename
-    if all(cellfun(@(x) strcmpi(fstruct.(x), mstruct.(x)), fields(mstruct), 'UniformOutput', true))
+    mfields = fields(mstruct);
+    mfieldmatches = zeros(1,numel(mfields));
+    for i = 1:numel(mfields)
+        if ismember(mfields{i}, fields(fstruct))
+            if strcmpi(mstruct.(mfields{i}), fstruct.(mfields{i}))
+                mfieldmatches(1,i) = 1;
+            end
+        end
+    end
+    if all(mfieldmatches)
         match = true;
         motion_file = fullfile(filepath, motion_file(counter).name);
     else
@@ -179,21 +188,6 @@ while ~match
     end
 end
 
-% issue with below code is that file name for all rp text files will be concatenated into motion_file variable (creates error)
-
-% if size(motion_file,1)>1
-%     % remove eventual prefix in case we need to match 
-%     % the realignement parameters with a realigned file
-%     % that was prefixed
-%     if strcmp(filename(1:3),'sub')
-%         motion_file = motion_file(arrayfun(@(x) contains(x.name, filename(1:round(length(x.name)/2))), motion_file));
-%     else
-%         unprefixed_filename = filename(3:end);
-%         motion_file = motion_file(arrayfun(@(x) contains(x.name, unprefixed_filename(1:round(length(x.name)/2))), motion_file));
-%     end
-% end
-% motion_file = fullfile(filepath, motion_file.name);
-
 if strcmpi(FramewiseDisplacement,'on')
     MotionParameters = 'on';
 end
@@ -203,7 +197,6 @@ if strcmpi(MotionParameters,'on')
 else
     FD = [];
 end
-
 %% look at globals
 
 if strcmpi(Globals,'on')   

--- a/bids/spmup_BIDS_preprocess.m
+++ b/bids/spmup_BIDS_preprocess.m
@@ -1089,11 +1089,14 @@ for frun = 1:size(Normalized_files,1)
             spm_smooth(Normalized_files{frun},stats_ready{frun},options.skernel);
             meta.smoothingkernel = skernel(1:3).*options.skernel;
         else % tiny kernel just to take closest neighbourghs
+            
+            % if skernel not specified, smooth by one voxel
+            if isempty(options.skernel)
+                options.skernel = 1;
+            end
+            skernel = skernel.*options.skernel;
             spm_smooth(Normalized_files{frun},stats_ready{frun},skernel(1:3));
             meta.smoothingkernel = skernel(1:3);
-            if isempty(options.skernel)
-                options.skernel = meta.smoothingkernel;
-            end
         end
         spm_jsonwrite(fullfile(filepath,[filename(1:end-5) '_desc-preprocessed_bold.json']),meta,opts)
     end


### PR DESCRIPTION
Previous version concatenated motion file names from all tasks within session, leading to error if ntasks > 1. Now assigns motion file that has filename fields that match image file.